### PR TITLE
better `binary_cross_entropy`; replace sigmoid

### DIFF
--- a/nbs/00_utils.ipynb
+++ b/nbs/00_utils.ipynb
@@ -578,8 +578,19 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def binary_cross_entropy(y_pred: chex.Array, y: chex.Array) -> chex.Array:\n",
-    "    return -(y * jnp.log(y_pred + 1e-5) + (1 - y) * jnp.log(1 - y_pred + 1e-5))\n"
+    "def binary_cross_entropy(\n",
+    "    preds: jnp.DeviceArray, # The predicted values\n",
+    "    labels: jnp.DeviceArray # The ground-truth labels\n",
+    ") -> jnp.DeviceArray: # Loss value\n",
+    "    \"\"\"Per-sample binary cross-entropy loss function.\"\"\"\n",
+    "\n",
+    "    # Clip the predictions to avoid NaNs in the log\n",
+    "    preds = jnp.clip(preds, 1e-7, 1 - 1e-7)\n",
+    "\n",
+    "    # Compute the binary cross-entropy\n",
+    "    loss = -labels * jnp.log(preds) - (1 - labels) * jnp.log(1 - preds)\n",
+    "\n",
+    "    return loss"
    ]
   },
   {
@@ -591,7 +602,7 @@
     "#| export\n",
     "def sigmoid(x):\n",
     "    # https://stackoverflow.com/a/68293931\n",
-    "    return 0.5 * (jnp.tanh(x / 2) + 1)\n"
+    "    return 0.5 * (jnp.tanh(x / 2) + 1)"
    ]
   },
   {

--- a/nbs/03_training_module.ipynb
+++ b/nbs/03_training_module.ipynb
@@ -283,7 +283,8 @@
     "            x, is_training\n",
     "        )\n",
     "        x = hk.Linear(1)(x)\n",
-    "        x = sigmoid(x)\n",
+    "        x = jax.nn.sigmoid(x)\n",
+    "        # x = sigmoid(x)\n",
     "        return x\n"
    ]
   },
@@ -672,7 +673,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cfnet",
+   "display_name": "nbdev2",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/05a_methods.vanilla.ipynb
+++ b/nbs/05a_methods.vanilla.ipynb
@@ -59,7 +59,8 @@
     "    apply_fn: Callable\n",
     ") -> jnp.DeviceArray:  # return `cf` shape: (k,)\n",
     "    def loss_fn_1(cf_y: jnp.DeviceArray, y_prime: jnp.DeviceArray):\n",
-    "        return jnp.mean(binary_cross_entropy(y_pred=cf_y, y=y_prime))\n",
+    "        return jnp.mean(binary_cross_entropy(preds=cf_y, labels=y_prime))\n",
+    "        # return jnp.mean(binary_cross_entropy(y_pred=cf_y, y=y_prime))\n",
     "\n",
     "    def loss_fn_2(x: jnp.DeviceArray, cf: jnp.DeviceArray):\n",
     "        return jnp.mean(optax.l2_loss(cf, x))\n",
@@ -208,9 +209,9 @@
      "output_type": "stream",
      "text": [
       "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n",
-      "/home/birk/code/cfnet/cfnet/_ckpt_manager.py:48: UserWarning: `monitor_metrics` is not specified in `CheckpointManager`. No checkpoints will be stored.\n",
+      "/home/birk/code/cfnet/relax/_ckpt_manager.py:48: UserWarning: `monitor_metrics` is not specified in `CheckpointManager`. No checkpoints will be stored.\n",
       "  \"`monitor_metrics` is not specified in `CheckpointManager`. No checkpoints will be stored.\"\n",
-      "Epoch 9: 100%|██████████| 10/10 [00:00<00:00, 87.77batch/s, train/train_loss_1=0.0615]\n"
+      "Epoch 9: 100%|██████████| 10/10 [00:00<00:00, 86.86batch/s, train/train_loss_1=0.0583]\n"
      ]
     }
    ],
@@ -263,7 +264,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1000/1000 [00:05<00:00, 185.48it/s]\n"
+      "100%|██████████| 1000/1000 [00:05<00:00, 186.16it/s]\n"
      ]
     }
    ],
@@ -324,17 +325,17 @@
        "    <tr>\n",
        "      <th>adult</th>\n",
        "      <th>VanillaCF</th>\n",
-       "      <td>0.825329</td>\n",
-       "      <td>0.167424</td>\n",
-       "      <td>7.3851247</td>\n",
+       "      <td>0.825943</td>\n",
+       "      <td>0.419236</td>\n",
+       "      <td>8.220324</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                      acc  validity  proximity\n",
-       "adult VanillaCF  0.825329  0.167424  7.3851247"
+       "                      acc  validity proximity\n",
+       "adult VanillaCF  0.825943  0.419236  8.220324"
       ]
      },
      "execution_count": null,

--- a/nbs/05c_methods.prototype.ipynb
+++ b/nbs/05c_methods.prototype.ipynb
@@ -172,7 +172,7 @@
     "        return ae.encode(ae_params, jax.random.PRNGKey(0), data)\n",
     "\n",
     "    def loss_fn_1(cf_y: jnp.DeviceArray, y_prime: jnp.DeviceArray):\n",
-    "        return jnp.mean(binary_cross_entropy(y_pred=cf_y, y=y_prime))\n",
+    "        return jnp.mean(binary_cross_entropy(preds=cf_y, labels=y_prime))\n",
     "\n",
     "    def loss_fn_2(x: jnp.DeviceArray, cf: jnp.DeviceArray):\n",
     "        return jnp.mean(optax.l2_loss(cf, x)) + 0.1 * jnp.mean(jnp.mean(jnp.abs(x - cf)))\n",
@@ -372,9 +372,9 @@
      "output_type": "stream",
      "text": [
       "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n",
-      "/home/birk/code/cfnet/cfnet/_ckpt_manager.py:48: UserWarning: `monitor_metrics` is not specified in `CheckpointManager`. No checkpoints will be stored.\n",
+      "/home/birk/code/cfnet/relax/_ckpt_manager.py:48: UserWarning: `monitor_metrics` is not specified in `CheckpointManager`. No checkpoints will be stored.\n",
       "  \"`monitor_metrics` is not specified in `CheckpointManager`. No checkpoints will be stored.\"\n",
-      "Epoch 9: 100%|██████████| 96/96 [00:01<00:00, 76.45batch/s, train/train_loss_1=0.081] \n"
+      "Epoch 9: 100%|██████████| 10/10 [00:00<00:00, 86.03batch/s, train/train_loss_1=0.0583]\n"
      ]
     }
    ],
@@ -434,8 +434,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch 4: 100%|██████████| 191/191 [00:00<00:00, 203.81batch/s, train/train_loss_1=0.386]\n",
-      "100%|██████████| 1000/1000 [00:14<00:00, 68.93it/s]\n"
+      "Epoch 4: 100%|██████████| 20/20 [00:00<00:00, 199.70batch/s, train/train_loss_1=0.307]\n",
+      "100%|██████████| 1000/1000 [00:18<00:00, 53.34it/s]\n"
      ]
     }
    ],
@@ -496,17 +496,17 @@
        "    <tr>\n",
        "      <th>adult</th>\n",
        "      <th>ProtoCF</th>\n",
-       "      <td>0.825697</td>\n",
-       "      <td>0.691684</td>\n",
-       "      <td>4.7873445</td>\n",
+       "      <td>0.825943</td>\n",
+       "      <td>0.851738</td>\n",
+       "      <td>8.070865</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                    acc  validity  proximity\n",
-       "adult ProtoCF  0.825697  0.691684  4.7873445"
+       "                    acc  validity proximity\n",
+       "adult ProtoCF  0.825943  0.851738  8.070865"
       ]
      },
      "execution_count": null,

--- a/nbs/05d_methods.counternet.ipynb
+++ b/nbs/05d_methods.counternet.ipynb
@@ -105,7 +105,7 @@
     "            z, is_training\n",
     "        )\n",
     "        y_hat = hk.Linear(1, name=\"Predictor\")(pred)\n",
-    "        y_hat = sigmoid(y_hat)\n",
+    "        y_hat = jax.nn.sigmoid(y_hat)\n",
     "\n",
     "        # explain\n",
     "        z_exp = jnp.concatenate((z, pred), axis=-1)\n",
@@ -781,7 +781,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cfnet",
+   "display_name": "nbdev2",
    "language": "python",
    "name": "python3"
   }

--- a/relax/methods/counternet.py
+++ b/relax/methods/counternet.py
@@ -47,7 +47,7 @@ class CounterNetModel(hk.Module):
             z, is_training
         )
         y_hat = hk.Linear(1, name="Predictor")(pred)
-        y_hat = sigmoid(y_hat)
+        y_hat = jax.nn.sigmoid(y_hat)
 
         # explain
         z_exp = jnp.concatenate((z, pred), axis=-1)

--- a/relax/methods/proto.py
+++ b/relax/methods/proto.py
@@ -119,7 +119,7 @@ def _proto_cf(
         return ae.encode(ae_params, jax.random.PRNGKey(0), data)
 
     def loss_fn_1(cf_y: jnp.DeviceArray, y_prime: jnp.DeviceArray):
-        return jnp.mean(binary_cross_entropy(y_pred=cf_y, y=y_prime))
+        return jnp.mean(binary_cross_entropy(preds=cf_y, labels=y_prime))
 
     def loss_fn_2(x: jnp.DeviceArray, cf: jnp.DeviceArray):
         return jnp.mean(optax.l2_loss(cf, x)) + 0.1 * jnp.mean(jnp.mean(jnp.abs(x - cf)))

--- a/relax/methods/vanilla.py
+++ b/relax/methods/vanilla.py
@@ -19,7 +19,8 @@ def _vanilla_cf(
     apply_fn: Callable
 ) -> jnp.DeviceArray:  # return `cf` shape: (k,)
     def loss_fn_1(cf_y: jnp.DeviceArray, y_prime: jnp.DeviceArray):
-        return jnp.mean(binary_cross_entropy(y_pred=cf_y, y=y_prime))
+        return jnp.mean(binary_cross_entropy(preds=cf_y, labels=y_prime))
+        # return jnp.mean(binary_cross_entropy(y_pred=cf_y, y=y_prime))
 
     def loss_fn_2(x: jnp.DeviceArray, cf: jnp.DeviceArray):
         return jnp.mean(optax.l2_loss(cf, x))

--- a/relax/module.py
+++ b/relax/module.py
@@ -93,7 +93,8 @@ class PredictiveModel(hk.Module):
             x, is_training
         )
         x = hk.Linear(1)(x)
-        x = sigmoid(x)
+        x = jax.nn.sigmoid(x)
+        # x = sigmoid(x)
         return x
 
 

--- a/relax/utils.py
+++ b/relax/utils.py
@@ -152,15 +152,24 @@ def add_to_class(cls):
 
 
 # %% ../nbs/00_utils.ipynb 41
-def binary_cross_entropy(y_pred: chex.Array, y: chex.Array) -> chex.Array:
-    return -(y * jnp.log(y_pred + 1e-5) + (1 - y) * jnp.log(1 - y_pred + 1e-5))
+def binary_cross_entropy(
+    preds: jnp.DeviceArray, # The predicted values
+    labels: jnp.DeviceArray # The ground-truth labels
+) -> jnp.DeviceArray: # Loss value
+    """Per-sample binary cross-entropy loss function."""
 
+    # Clip the predictions to avoid NaNs in the log
+    preds = jnp.clip(preds, 1e-7, 1 - 1e-7)
+
+    # Compute the binary cross-entropy
+    loss = -labels * jnp.log(preds) - (1 - labels) * jnp.log(1 - preds)
+
+    return loss
 
 # %% ../nbs/00_utils.ipynb 42
 def sigmoid(x):
     # https://stackoverflow.com/a/68293931
     return 0.5 * (jnp.tanh(x / 2) + 1)
-
 
 # %% ../nbs/00_utils.ipynb 44
 def accuracy(y_true: jnp.ndarray, y_pred: jnp.ndarray) -> jnp.DeviceArray:


### PR DESCRIPTION
* better `binary_cross_entropy` implementation
* replace `sigmoid` in model implementations with `jax.nn.sigmoid` (faster training)