### PR TITLE
Sample data first before load to numpy array

### DIFF
--- a/nbs/01_data.module.ipynb
+++ b/nbs/01_data.module.ipynb
@@ -49,7 +49,8 @@
     "from sklearn.preprocessing import StandardScaler, MinMaxScaler, OneHotEncoder\n",
     "from sklearn.base import TransformerMixin\n",
     "from urllib.request import urlretrieve\n",
-    "from relax.data.loader import Dataset, ArrayDataset, DataLoader, DataloaderBackends"
+    "from relax.data.loader import Dataset, ArrayDataset, DataLoader, DataloaderBackends\n",
+    "from copy import deepcopy"
    ]
   },
   {
@@ -213,6 +214,12 @@
     "def _process_data(\n",
     "    df: pd.DataFrame | None, configs: TabularDataModuleConfigs\n",
     ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    This function does the following:\n",
+    "        * Check and load data.\n",
+    "        * Select first `sample_frac` of the data.\n",
+    "        * Check and load only specified columns.\n",
+    "    \"\"\"\n",
     "    if df is None:\n",
     "        df = pd.read_csv(configs.data_dir)\n",
     "    elif isinstance(df, pd.DataFrame):\n",
@@ -220,6 +227,10 @@
     "    else:\n",
     "        raise ValueError(f\"{type(df).__name__} is not supported as an input type for `TabularDataModule`.\")\n",
     "\n",
+    "    if configs.sample_frac is not None:\n",
+    "        sample_size = int(len(df) * configs.sample_frac)\n",
+    "        df = df.iloc[:sample_size]\n",
+    "    \n",
     "    df = _check_cols(df, configs)\n",
     "    return df"
    ]
@@ -401,7 +412,7 @@
     "        ge=0., le=1.0\n",
     "    )\n",
     "    backend: str = Field(\n",
-    "        \"jax\", description=f\"`Dataloader` backend. Currently supports: {_supported_backends()}\"\n",
+    "        \"jax\", description=f\"`Dataloader` backend. Currently supports: {DataloaderBackends.supported()}\"\n",
     "    )\n"
    ]
   },
@@ -415,7 +426,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L187){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L196){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModuleConfigs\n",
        "\n",
@@ -445,7 +456,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L187){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L196){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModuleConfigs\n",
        "\n",
@@ -504,7 +515,7 @@
     "    imutable_cols=[\"age\", \"workclass\", \"marital_status\"],\n",
     "    normalizer=None, \n",
     "    encoder=None, \n",
-    "    sample_frac=0.1,\n",
+    "    sample_frac=None,\n",
     "    backend='jax'\n",
     ")"
    ]
@@ -555,9 +566,9 @@
     "        train_X, test_X, train_y, test_y = map(\n",
     "             lambda x: x.astype(float), train_test_tuple\n",
     "         )\n",
-    "        if self._configs.sample_frac:\n",
-    "            train_size = int(len(train_X) * self._configs.sample_frac)\n",
-    "            train_X, train_y = train_X[:train_size], train_y[:train_size]\n",
+    "        # if self._configs.sample_frac:\n",
+    "        #     train_size = int(len(train_X) * self._configs.sample_frac)\n",
+    "        #     train_X, train_y = train_X[:train_size], train_y[:train_size]\n",
     "        \n",
     "        self._train_dataset = ArrayDataset(train_X, train_y)\n",
     "        self._val_dataset = ArrayDataset(test_X, test_y)\n",
@@ -720,6 +731,31 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If `TabularDataModuleConfigs.sample_frac` is set to a float value,\n",
+    "internally, the `TabularDataModule` will load the first `sample_frac` \n",
+    "of data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "configs01 = deepcopy(configs)\n",
+    "configs01.sample_frac = 0.1\n",
+    "dm = TabularDataModule(configs01, data=df)\n",
+    "assert len(dm.data) == 100 # dm contains 10% of `df`\n",
+    "assert dm.data[configs.discret_cols].equals(\n",
+    "    df[:100][configs.discret_cols]\n",
+    ") # dm contains the same 10% of `df` data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -729,7 +765,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L268){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L277){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.data\n",
        "\n",
@@ -740,7 +776,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L268){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L277){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.data\n",
        "\n",
@@ -901,7 +937,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L300){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L317){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.transform\n",
        "\n",
@@ -917,7 +953,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L300){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L317){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.transform\n",
        "\n",
@@ -978,7 +1014,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L317){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L334){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.inverse_transform\n",
        "\n",
@@ -998,7 +1034,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L317){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L334){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.inverse_transform\n",
        "\n",
@@ -1276,7 +1312,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L338){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L355){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.apply_constraints\n",
        "\n",
@@ -1297,7 +1333,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L338){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L355){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.apply_constraints\n",
        "\n",
@@ -1340,15 +1376,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "x, y = next(iter(dm.test_dataloader(batch_size=128)))\n",
     "# unnormalized counterfactuals\n",
@@ -1369,7 +1397,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L357){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L374){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.apply_regularization\n",
        "\n",
@@ -1389,7 +1417,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/birkhoffg/cfnet/tree/master/blob/master/relax/data/module.py#L357){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/birkhoffg/relax/tree/master/blob/master/relax/data/module.py#L374){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### TabularDataModule.apply_regularization\n",
        "\n",
@@ -1479,6 +1507,10 @@
     "    x, y = next(iter(dl))\n",
     "    assert x.shape[0] == batch_size\n",
     "\n",
+    "    assert len(dm.data) == len(dm.train_dataset) + len(dm.val_dataset)\n",
+    "    sample_frac = 1.0 if data_configs.sample_frac is None else data_configs.sample_frac\n",
+    "    assert len(dm.data) == int(len(pd.read_csv(data_configs.data_dir)) * sample_frac)\n",
+    "\n",
     "    ############################################################\n",
     "    # test `transform` and `inverse_transform`\n",
     "    ############################################################\n",
@@ -1512,16 +1544,6 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "from copy import deepcopy"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| hide\n",
     "data_configs = {\n",
     "    \"data_dir\": \"assets/data/s_adult.csv\",\n",
     "    \"data_name\": \"adult\",\n",
@@ -1534,6 +1556,19 @@
     "}\n",
     "dm = TabularDataModule(data_configs)\n",
     "check_datamodule(dm, data_configs)\n",
+    "\n",
+    "# sample_frac=None\n",
+    "_data_configs = deepcopy(data_configs)\n",
+    "_data_configs[\"sample_frac\"] = None\n",
+    "dm = TabularDataModule(data_configs)\n",
+    "check_datamodule(dm, data_configs)\n",
+    "\n",
+    "# sample_frac=0\n",
+    "_data_configs = deepcopy(data_configs)\n",
+    "_data_configs[\"sample_frac\"] = 0.\n",
+    "dm = TabularDataModule(data_configs)\n",
+    "check_datamodule(dm, data_configs)\n",
+    "\n",
     "\n",
     "# immutable\n",
     "_data_configs = deepcopy(data_configs)\n",

--- a/relax/data/module.py
+++ b/relax/data/module.py
@@ -8,6 +8,7 @@ from sklearn.preprocessing import StandardScaler, MinMaxScaler, OneHotEncoder
 from sklearn.base import TransformerMixin
 from urllib.request import urlretrieve
 from .loader import Dataset, ArrayDataset, DataLoader, DataloaderBackends
+from copy import deepcopy
 
 # %% auto 0
 __all__ = ['BaseDataModule', 'find_imutable_idx_list', 'TabularDataModuleConfigs', 'TabularDataModule', 'sample', 'load_data']
@@ -134,6 +135,10 @@ def _process_data(
     else:
         raise ValueError(f"{type(df).__name__} is not supported as an input type for `TabularDataModule`.")
 
+    if configs.sample_frac is not None:
+        sample_size = int(len(df) * configs.sample_frac)
+        df = df.iloc[:sample_size]
+    
     df = _check_cols(df, configs)
     return df
 
@@ -260,9 +265,9 @@ class TabularDataModule(BaseDataModule):
         train_X, test_X, train_y, test_y = map(
              lambda x: x.astype(float), train_test_tuple
          )
-        if self._configs.sample_frac:
-            train_size = int(len(train_X) * self._configs.sample_frac)
-            train_X, train_y = train_X[:train_size], train_y[:train_size]
+        # if self._configs.sample_frac:
+        #     train_size = int(len(train_X) * self._configs.sample_frac)
+        #     train_X, train_y = train_X[:train_size], train_y[:train_size]
         
         self._train_dataset = ArrayDataset(train_X, train_y)
         self._val_dataset = ArrayDataset(test_X, test_y)
@@ -387,13 +392,13 @@ class TabularDataModule(BaseDataModule):
         return reg_loss
 
 
-# %% ../../nbs/01_data.module.ipynb 41
+# %% ../../nbs/01_data.module.ipynb 43
 def sample(datamodule: BaseDataModule, frac: float = 1.0): 
     X, y = datamodule.train_dataset[:]
     size = int(len(X) * frac)
     return X[:size], y[:size]
 
-# %% ../../nbs/01_data.module.ipynb 46
+# %% ../../nbs/01_data.module.ipynb 47
 DEFAULT_DATA_CONFIGS = {
     'adult': {
         'data' :'assets/data/s_adult.csv',
@@ -409,13 +414,13 @@ DEFAULT_DATA_CONFIGS = {
     }
 }
 
-# %% ../../nbs/01_data.module.ipynb 47
+# %% ../../nbs/01_data.module.ipynb 48
 def _validate_dataname(data_name: str):
     if data_name not in DEFAULT_DATA_CONFIGS.keys():
         raise ValueError(f'`data_name` must be one of {DEFAULT_DATA_CONFIGS.keys()}, '
             f'but got data_name={data_name}.')
 
-# %% ../../nbs/01_data.module.ipynb 48
+# %% ../../nbs/01_data.module.ipynb 49
 def load_data(
     data_name: str, # The name of data
     return_config: bool = False, # Return `data_config `or not


### PR DESCRIPTION
Before, even if `sample_frac` is set, we use the entire data for building `train_dataset`, `val_dataset`, `test_dataset`. 

When data is very large, this approach could unwantedly blow the memory because building datasets ( `train_dataset` etc.) assign new memory.

Now, I only load data with first `sample_frac` of data. 